### PR TITLE
Fix documentation copy

### DIFF
--- a/distribution/src/main/resources/assemblies/full.xml
+++ b/distribution/src/main/resources/assemblies/full.xml
@@ -80,11 +80,6 @@
         <fileSet>
             <directory>${project.basedir}/../target/site/apidocs</directory>
             <outputDirectory>doc/java</outputDirectory>
-            <includes>
-                <include>
-                    *
-                </include>
-            </includes>
             <fileMode>0644</fileMode>
         </fileSet>
 
@@ -92,9 +87,6 @@
         <fileSet>
             <directory>${project.basedir}/../build/html</directory>
             <outputDirectory>doc/cpp</outputDirectory>
-            <includes>
-                <include>*</include>
-            </includes>
             <fileMode>0644</fileMode>
         </fileSet>
 


### PR DESCRIPTION
The following command doesn't work as expected: only the first level of the API documentation folder is copied in the distribution target forlder.
"mvn -f distribution/pom.xml install"