### PR TITLE
fix ibiblio repository url

### DIFF
--- a/iidm-ddb/iidm-ddb-ejb-remote-client-wildfly/pom.xml
+++ b/iidm-ddb/iidm-ddb-ejb-remote-client-wildfly/pom.xml
@@ -25,7 +25,7 @@
     <repositories>
         <repository>
             <id>ibiblio.org-releases</id>
-            <url>http://mirrors.ibiblio.org/maven2/</url>
+            <url>http://maven.ibiblio.org/maven2/</url>
         </repository>
 
         <repository>


### PR DESCRIPTION
fix ibiblio repository url in iidm-ddb-ejb-remote-clientwildfly pom file