### PR TITLE
when the involved esgId's length is not OK, skips the mapping (with a…

### DIFF
--- a/eurostag-ech-export/src/main/java/eu/itesla_project/iidm/eurostag/export/DicoEurostagNamingStrategy.java
+++ b/eurostag-ech-export/src/main/java/eu/itesla_project/iidm/eurostag/export/DicoEurostagNamingStrategy.java
@@ -76,8 +76,8 @@ public class DicoEurostagNamingStrategy implements EurostagNamingStrategy {
                 String iidmId = row.get(0).trim();
                 String esgId = row.get(1).trim();
                 if (esgId.length() > NameType.GENERATOR.getLength()) {
-                    String errMsg = "esgId: " + esgId + " 's length > " + NameType.GENERATOR.getLength() + ".  Line " + count + " in " + dicoFile.toString();
-                    throw new RuntimeException(errMsg);
+                    LOGGER.warn("Skipping mapping iidmId: " + iidmId + ", esgId: " + esgId + ". esgId's length > " + NameType.GENERATOR.getLength() + ".  Line " + count + " in " + dicoFile.toString());
+                    continue;
                 }
                 if ("".equals(iidmId) || "".equals(esgId)) {
                     String errMsg = "either iidmId or esgId or both are empty strings. Line " + count + " in " + dicoFile.toString();


### PR DESCRIPTION
… warning)