### PR TITLE
Change printLimitViolations call to avoid regression

### DIFF
--- a/modules/src/main/java/eu/itesla_project/modules/OptimizerTool.java
+++ b/modules/src/main/java/eu/itesla_project/modules/OptimizerTool.java
@@ -7,6 +7,7 @@
 package eu.itesla_project.modules;
 
 import com.google.auto.service.AutoService;
+import com.powsybl.security.LimitViolationFilter;
 import com.powsybl.tools.Command;
 import com.powsybl.tools.Tool;
 import com.powsybl.tools.ToolRunningContext;
@@ -150,7 +151,7 @@ public class OptimizerTool implements Tool {
                 context.getOutputStream().println("loadflow status is " + (result2.isOk() ? "ok" : "nok") + " (" + result2.getMetrics() + ")");
 
                 if (result2.isOk() && checkConstraints) {
-                    String report = Security.printLimitsViolations(network);
+                    String report = Security.printLimitsViolations(network, LimitViolationFilter.load());
                     if (report != null) {
                         context.getOutputStream().println(report);
                     }

--- a/offline-workflow/src/main/java/eu/itesla_project/offline/OfflineWorkflowImpl.java
+++ b/offline-workflow/src/main/java/eu/itesla_project/offline/OfflineWorkflowImpl.java
@@ -15,6 +15,7 @@ import com.powsybl.loadflow.LoadFlow;
 import com.powsybl.loadflow.LoadFlowFactory;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.loadflow.LoadFlowResult;
+import com.powsybl.security.LimitViolationFilter;
 import eu.itesla_project.merge.MergeOptimizerFactory;
 import eu.itesla_project.modules.*;
 import eu.itesla_project.cases.CaseRepository;
@@ -222,7 +223,7 @@ public class OfflineWorkflowImpl extends AbstractOfflineWorkflow {
 
     protected SimulationState runStabilization(WorkflowContext context, WorkflowStartContext startContext, int sampleId) {
         // before dynamic simualtion, check there is no static constraints
-        String report = Security.printLimitsViolations(context.getNetwork());
+        String report = Security.printLimitsViolations(context.getNetwork(), LimitViolationFilter.load());
         if (report != null) {
             LOGGER.warn("Constraints for sample {}:\n{}", sampleId, report);
         }


### PR DESCRIPTION
The printLimitViolations(List<LimitViolation>) method won't filter the violations in a future version.