### PR TITLE
Dummy histodbclient

### DIFF
--- a/modules/src/main/java/eu/itesla_project/modules/test/HistoDbClientTestFactoryImpl.java
+++ b/modules/src/main/java/eu/itesla_project/modules/test/HistoDbClientTestFactoryImpl.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package eu.itesla_project.modules.test;
+
+import eu.itesla_project.modules.histo.HistoDbClient;
+import eu.itesla_project.modules.histo.HistoDbClientFactory;
+
+/**
+ * @author Christian Biasuzzi <christian.biasuzzi@techrain.it>
+ */
+public class HistoDbClientTestFactoryImpl implements HistoDbClientFactory {
+
+    @Override
+    public HistoDbClient create(boolean cache) {
+        return new HistoDbClientTestImpl();
+    }
+
+}

--- a/modules/src/main/java/eu/itesla_project/modules/test/HistoDbClientTestImpl.java
+++ b/modules/src/main/java/eu/itesla_project/modules/test/HistoDbClientTestImpl.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2017, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package eu.itesla_project.modules.test;
+
+import com.powsybl.iidm.network.Country;
+import eu.itesla_project.modules.histo.*;
+import eu.itesla_project.modules.histo.cache.HistoDbCache;
+import org.joda.time.Interval;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Christian Biasuzzi <christian.biasuzzi@techrain.it>
+ */
+public class HistoDbClientTestImpl implements HistoDbClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HistoDbClientTestImpl.class);
+
+    private InputStream createInputStreamFromAnEmptyString() {
+        return new ByteArrayInputStream("".getBytes());
+    }
+
+    @Override
+    public HistoDbCache getCache() {
+        return null;
+    }
+
+
+    @Override
+    public List<HistoDbAttributeId> listAttributes() throws IOException {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public int queryCount(Interval interval, HistoDbHorizon horizon) throws IOException {
+        return 0;
+    }
+
+    @Override
+    public HistoDbStats queryStats(Set<Country> countries, Set<HistoDbEquip> equips,
+                                   Set<HistoDbAttr> attrs, Interval interval, HistoDbHorizon horizon, boolean async) throws IOException, InterruptedException {
+        return new HistoDbStats();
+    }
+
+    @Override
+    public HistoDbStats queryStats(Set<HistoDbAttributeId> attrIds, Interval interval, HistoDbHorizon horizon, boolean async) throws IOException, InterruptedException {
+        return new HistoDbStats();
+    }
+
+
+    @Override
+    public InputStream queryCsv(HistoQueryType queryType, Set<Country> countries, Set<HistoDbEquip> equips,
+                                Set<HistoDbAttr> attrs, Interval interval, HistoDbHorizon horizon, boolean zipped, boolean async) throws IOException, InterruptedException {
+        return createInputStreamFromAnEmptyString();
+    }
+
+    @Override
+    public InputStream queryCsv(HistoQueryType queryType, Set<HistoDbAttributeId> attrIds, Interval interval, HistoDbHorizon horizon, boolean zipped, boolean async) throws IOException, InterruptedException {
+        return createInputStreamFromAnEmptyString();
+    }
+
+
+    @Override
+    public List<String> listDbs() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getDbName() {
+        return "";
+    }
+
+    @Override
+    public void setDbName(String dbName) {
+        LOGGER.info("set db to {} ", dbName);
+    }
+
+    @Override
+    public void clearDb() {
+        LOGGER.info("cleardb");
+    }
+
+    @Override
+    public void clearDb(String dbName) {
+        LOGGER.info("cleardb({})", dbName);
+    }
+
+    @Override
+    public void close() throws Exception {
+    }
+
+}

--- a/modules/src/main/java/eu/itesla_project/modules/test/RulesDbClientTestFactoryImpl.java
+++ b/modules/src/main/java/eu/itesla_project/modules/test/RulesDbClientTestFactoryImpl.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package eu.itesla_project.modules.test;
+
+import eu.itesla_project.modules.rules.RulesDbClient;
+import eu.itesla_project.modules.rules.RulesDbClientFactory;
+
+/**
+ * @author Christian Biasuzzi <christian.biasuzzi@techrain.it>
+ */
+public class RulesDbClientTestFactoryImpl implements RulesDbClientFactory {
+
+    @Override
+    public RulesDbClient create(String rulesDbName) {
+        return new RulesDbClientTestImpl();
+    }
+
+}

--- a/modules/src/main/java/eu/itesla_project/modules/test/RulesDbClientTestImpl.java
+++ b/modules/src/main/java/eu/itesla_project/modules/test/RulesDbClientTestImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package eu.itesla_project.modules.test;
+
+import com.powsybl.simulation.securityindexes.SecurityIndexType;
+import eu.itesla_project.modules.rules.RuleAttributeSet;
+import eu.itesla_project.modules.rules.RuleId;
+import eu.itesla_project.modules.rules.RulesDbClient;
+import eu.itesla_project.modules.rules.SecurityRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Christian Biasuzzi <christian.biasuzzi@techrain.it>
+ */
+public class RulesDbClientTestImpl implements RulesDbClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RulesDbClientTestImpl.class);
+
+
+    @Override
+    public void close() throws Exception {
+    }
+
+    @Override
+    public List<String> listWorkflows() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void updateRule(SecurityRule rule) {
+        LOGGER.info("updateRule ({})", rule);
+    }
+
+    @Override
+    public List<SecurityRule> getRules(String workflowId, RuleAttributeSet attributeSet, String contingencyId, SecurityIndexType securityIndexType) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<RuleId> listRules(String workflowId, RuleAttributeSet attributeSet) {
+        return Collections.emptyList();
+    }
+
+}

--- a/modules/src/test/java/eu/itesla_project/modules/histo/HistoDbDummyClientTest.java
+++ b/modules/src/test/java/eu/itesla_project/modules/histo/HistoDbDummyClientTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2017, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package eu.itesla_project.modules.histo;
+
+import eu.itesla_project.modules.test.HistoDbClientTestFactoryImpl;
+import org.apache.commons.io.IOUtils;
+import org.joda.time.Interval;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Christian Biasuzzi <christian.biasuzzi@techrain.it>
+ */
+public class HistoDbDummyClientTest {
+
+
+    @Test
+    public void testCreateClient() {
+        HistoDbClient histoDbClient = new HistoDbClientTestFactoryImpl().create(false);
+        assertNull(histoDbClient.getCache());
+    }
+
+
+    @Test
+    public void testmethods() throws IOException, InterruptedException {
+        Interval interval = Interval.parse("2013-01-14T00:00:00+01:00/2013-01-14T01:00:00+01:00");
+        HistoDbClient histoDbClient = new HistoDbClientTestFactoryImpl().create(false);
+        assertEquals(histoDbClient.getDbName(), "");
+        assertTrue(histoDbClient.listDbs().size() == 0);
+        assertTrue(histoDbClient.queryCount(interval, HistoDbHorizon.SN) == 0);
+        assertEquals(histoDbClient.listAttributes(), Collections.emptyList());
+        assertEquals(IOUtils.toString(histoDbClient.queryCsv(HistoQueryType.data, Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), interval, HistoDbHorizon.SN, true, true), StandardCharsets.UTF_8), "");
+        assertEquals(IOUtils.toString(histoDbClient.queryCsv(HistoQueryType.data, Collections.emptySet(), interval, HistoDbHorizon.SN, true, true), StandardCharsets.UTF_8), "");
+        assertNotNull(histoDbClient.queryStats(Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), interval, HistoDbHorizon.SN, true));
+        assertNotNull(histoDbClient.queryStats(Collections.emptySet(), interval, HistoDbHorizon.SN, true));
+    }
+
+}

--- a/modules/src/test/java/eu/itesla_project/modules/histo/RuleDbDummyClientTest.java
+++ b/modules/src/test/java/eu/itesla_project/modules/histo/RuleDbDummyClientTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package eu.itesla_project.modules.histo;
+
+import com.powsybl.simulation.securityindexes.SecurityIndexType;
+import eu.itesla_project.modules.rules.RuleAttributeSet;
+import eu.itesla_project.modules.rules.RulesDbClient;
+import eu.itesla_project.modules.test.RulesDbClientTestFactoryImpl;
+import org.joda.time.Interval;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Christian Biasuzzi <christian.biasuzzi@techrain.it>
+ */
+public class RuleDbDummyClientTest {
+
+    @Test
+    public void testCreateClient() {
+        RulesDbClient ruleDbClient = new RulesDbClientTestFactoryImpl().create("RULEDBNAME");
+        assertNotNull(ruleDbClient);
+    }
+
+    @Test
+    public void testmethods() throws IOException, InterruptedException {
+        Interval interval = Interval.parse("2013-01-14T00:00:00+01:00/2013-01-14T01:00:00+01:00");
+        String rulesDbName = "DUMMYRULEDBNAMW";
+        String wfId = "DUMMYWORKFLOWID";
+        String contingencyId = "DUMMYCONTINGENCYID";
+
+        RulesDbClient ruleDbClient = new RulesDbClientTestFactoryImpl().create(rulesDbName);
+        assertEquals(ruleDbClient.listWorkflows(), Collections.emptyList());
+        assertEquals(ruleDbClient.getRules(wfId, RuleAttributeSet.WORST_CASE, contingencyId, SecurityIndexType.TSO_OVERLOAD), Collections.emptyList());
+        assertEquals(ruleDbClient.listRules(wfId, RuleAttributeSet.WORST_CASE), Collections.emptyList());
+    }
+
+}


### PR DESCRIPTION
dummy histodb-client implementation that does nothing. Can be used for test purposes, does not require any configuration.