### PR TITLE
Eurostag ech export: export only main connected component

### DIFF
--- a/eurostag-ech-export/src/main/java/eu/itesla_project/iidm/eurostag/export/EchUtil.java
+++ b/eurostag-ech-export/src/main/java/eu/itesla_project/iidm/eurostag/export/EchUtil.java
@@ -7,6 +7,7 @@
 package eu.itesla_project.iidm.eurostag.export;
 
 import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.util.ConnectedComponents;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -37,12 +38,16 @@ public final class EchUtil {
         return dl.getId() + "_LOAD";
     }
 
-    public static Bus getBus(Terminal t, EurostagEchExportConfig config) {
-        if (config.isNoSwitch()) {
+    public static Bus getBus(Terminal t, boolean noswitch) {
+        if (noswitch) {
             return t.getBusView().getBus();
         } else {
             return t.getBusBreakerView().getBus();
         }
+    }
+
+    public static Bus getBus(Terminal t, EurostagEchExportConfig config) {
+        return EchUtil.getBus(t, config.isNoSwitch());
     }
 
     public static Iterable<Bus> getBuses(Network n, EurostagEchExportConfig config) {
@@ -166,4 +171,16 @@ public final class EchUtil {
                 .orElse(null);
     }
 
+    public static boolean isInMainCc(Bus bus) {
+        return ConnectedComponents.getCcNum(bus) == Component.MAIN_NUM;
+    }
+
+    public static boolean isInMainCc(Injection injection, boolean noswitch) {
+        return ConnectedComponents.getCcNum(EchUtil.getBus(injection.getTerminal(), noswitch)) == Component.MAIN_NUM;
+    }
+
+    public static boolean isInMainCc(Branch branch, boolean noswitch) {
+        return (ConnectedComponents.getCcNum(EchUtil.getBus(branch.getTerminal1(), noswitch)) == Component.MAIN_NUM)
+                && (ConnectedComponents.getCcNum(EchUtil.getBus(branch.getTerminal2(), noswitch)) == Component.MAIN_NUM);
+    }
 }

--- a/eurostag-ech-export/src/main/java/eu/itesla_project/iidm/eurostag/export/EurostagDictionary.java
+++ b/eurostag-ech-export/src/main/java/eu/itesla_project/iidm/eurostag/export/EurostagDictionary.java
@@ -9,7 +9,6 @@ package eu.itesla_project.iidm.eurostag.export;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
-import com.powsybl.iidm.network.util.ConnectedComponents;
 import eu.itesla_project.eurostag.network.Esg8charName;
 import eu.itesla_project.eurostag.network.EsgBranchName;
 import com.powsybl.iidm.network.*;
@@ -64,7 +63,7 @@ public final class EurostagDictionary {
 
         for (DanglingLine dl : Identifiables.sort(network.getDanglingLines())) {
             // skip if not in the main connected component
-            if (config.isExportMainCCOnly() && (ConnectedComponents.getCcNum(EchUtil.getBus(dl.getTerminal(), config)) != Component.MAIN_NUM)) {
+            if (config.isExportMainCCOnly() && !EchUtil.isInMainCc(dl, config.isNoSwitch())) {
                 continue;
             }
             ConnectionBus bus1 = ConnectionBus.fromTerminal(dl.getTerminal(), config, fakeNodes);
@@ -79,8 +78,7 @@ public final class EurostagDictionary {
                 Bus bus1 = EchUtil.getBus1(vl, sw.getId(), config);
                 Bus bus2 = EchUtil.getBus2(vl, sw.getId(), config);
                 // skip switches not in the main connected component
-                if (config.isExportMainCCOnly() && ((ConnectedComponents.getCcNum(bus1) != Component.MAIN_NUM)
-                        || (ConnectedComponents.getCcNum(bus2) != Component.MAIN_NUM))) {
+                if (config.isExportMainCCOnly() && (!EchUtil.isInMainCc(bus1) || !EchUtil.isInMainCc(bus2))) {
                     continue;
                 }
                 dictionary.addIfNotExist(sw.getId(),
@@ -92,8 +90,7 @@ public final class EurostagDictionary {
 
         for (Line l : Identifiables.sort(network.getLines())) {
             // skip lines not in the main connected component
-            if (config.isExportMainCCOnly() && ((ConnectedComponents.getCcNum(EchUtil.getBus(l.getTerminal1(), config)) != Component.MAIN_NUM)
-                    || (ConnectedComponents.getCcNum(EchUtil.getBus(l.getTerminal2(), config)) != Component.MAIN_NUM))) {
+            if (config.isExportMainCCOnly() && !EchUtil.isInMainCc(l, config.isNoSwitch())) {
                 continue;
             }
             ConnectionBus bus1 = ConnectionBus.fromTerminal(l.getTerminal1(), config, fakeNodes);
@@ -106,8 +103,7 @@ public final class EurostagDictionary {
 
         for (TwoWindingsTransformer twt : Identifiables.sort(network.getTwoWindingsTransformers())) {
             // skip transformers not in the main connected component
-            if (config.isExportMainCCOnly() && ((ConnectedComponents.getCcNum(EchUtil.getBus(twt.getTerminal1(), config)) != Component.MAIN_NUM)
-                    || (ConnectedComponents.getCcNum(EchUtil.getBus(twt.getTerminal2(), config)) != Component.MAIN_NUM))) {
+            if (config.isExportMainCCOnly() && !EchUtil.isInMainCc(twt, config.isNoSwitch())) {
                 continue;
             }
             ConnectionBus bus1 = ConnectionBus.fromTerminal(twt.getTerminal1(), config, fakeNodes);

--- a/eurostag-ech-export/src/main/java/eu/itesla_project/iidm/eurostag/export/EurostagEchExport.java
+++ b/eurostag-ech-export/src/main/java/eu/itesla_project/iidm/eurostag/export/EurostagEchExport.java
@@ -10,7 +10,6 @@ package eu.itesla_project.iidm.eurostag.export;
 import com.google.common.base.Strings;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
-import com.powsybl.iidm.network.util.ConnectedComponents;
 import com.powsybl.iidm.network.util.Identifiables;
 import eu.itesla_project.eurostag.network.*;
 import eu.itesla_project.eurostag.network.io.EsgWriter;
@@ -104,7 +103,7 @@ public class EurostagEchExport {
         LOGGER.debug("Slack bus: {} ({})", sb, sb.getVoltageLevel().getId());
         for (Bus b : Identifiables.sort(EchUtil.getBuses(network, config))) {
             // skip buses not in the main connected component
-            if (config.isExportMainCCOnly() && (ConnectedComponents.getCcNum(b) != Component.MAIN_NUM)) {
+            if (config.isExportMainCCOnly() && !EchUtil.isInMainCc(b)) {
                 LOGGER.warn("not in main component, skipping Bus: {}", b.getId());
                 continue;
             }
@@ -112,7 +111,7 @@ public class EurostagEchExport {
         }
         for (DanglingLine dl : Identifiables.sort(network.getDanglingLines())) {
             // skip DLs not in the main connected component
-            if (config.isExportMainCCOnly() && (ConnectedComponents.getCcNum(EchUtil.getBus(dl.getTerminal(), config)) != Component.MAIN_NUM)) {
+            if (config.isExportMainCCOnly() && !EchUtil.isInMainCc(dl, config.isNoSwitch())) {
                 LOGGER.warn("not in main component, skipping DanglingLine: {}", dl.getId());
                 continue;
             }
@@ -142,8 +141,7 @@ public class EurostagEchExport {
                 Bus bus1 = EchUtil.getBus1(vl, sw.getId(), config);
                 Bus bus2 = EchUtil.getBus2(vl, sw.getId(), config);
                 // skip switches not in the main connected component
-                if (config.isExportMainCCOnly() && ((ConnectedComponents.getCcNum(bus1) != Component.MAIN_NUM)
-                        || (ConnectedComponents.getCcNum(bus2) != Component.MAIN_NUM))) {
+                if (config.isExportMainCCOnly() && (!EchUtil.isInMainCc(bus1) || !EchUtil.isInMainCc(bus2))) {
                     LOGGER.warn("not in main component, skipping Switch: {} {} {}", bus1.getId(), bus2.getId(), sw.getId());
                     continue;
                 }
@@ -192,8 +190,7 @@ public class EurostagEchExport {
     private void createLines(EsgNetwork esgNetwork, EsgGeneralParameters parameters) {
         for (Line l : Identifiables.sort(network.getLines())) {
             // skip lines not in the main connected component
-            if (config.isExportMainCCOnly() && ((ConnectedComponents.getCcNum(EchUtil.getBus(l.getTerminal1(), config)) != Component.MAIN_NUM)
-                    || (ConnectedComponents.getCcNum(EchUtil.getBus(l.getTerminal2(), config)) != Component.MAIN_NUM))) {
+            if (config.isExportMainCCOnly() && !EchUtil.isInMainCc(l, config.isNoSwitch())) {
                 LOGGER.warn("not in main component, skipping Line: {}", l.getId());
                 continue;
             }
@@ -222,7 +219,7 @@ public class EurostagEchExport {
         }
         for (DanglingLine dl : Identifiables.sort(network.getDanglingLines())) {
             // skip if not in the main connected component
-            if (config.isExportMainCCOnly() && (ConnectedComponents.getCcNum(EchUtil.getBus(dl.getTerminal(), config)) != Component.MAIN_NUM)) {
+            if (config.isExportMainCCOnly() && !EchUtil.isInMainCc(dl, config.isNoSwitch())) {
                 LOGGER.warn("not in main component, skipping DanglingLine: {}", dl.getId());
                 continue;
             }
@@ -294,8 +291,7 @@ public class EurostagEchExport {
 
         for (TwoWindingsTransformer twt : Identifiables.sort(network.getTwoWindingsTransformers())) {
             // skip transformers not in the main connected component
-            if (config.isExportMainCCOnly() && ((ConnectedComponents.getCcNum(EchUtil.getBus(twt.getTerminal1(), config)) != Component.MAIN_NUM)
-                    || (ConnectedComponents.getCcNum(EchUtil.getBus(twt.getTerminal2(), config)) != Component.MAIN_NUM))) {
+            if (config.isExportMainCCOnly() && !EchUtil.isInMainCc(twt, config.isNoSwitch())) {
                 LOGGER.warn("not in main component, skipping TwoWindingsTransformer: {}", twt.getId());
                 continue;
             }
@@ -463,7 +459,7 @@ public class EurostagEchExport {
     private void createLoads(EsgNetwork esgNetwork) {
         for (Load l : Identifiables.sort(network.getLoads())) {
             // skip loads not in the main connected component
-            if (config.isExportMainCCOnly() && (ConnectedComponents.getCcNum(EchUtil.getBus(l.getTerminal(), config)) != Component.MAIN_NUM)) {
+            if (config.isExportMainCCOnly() && !EchUtil.isInMainCc(l, config.isNoSwitch())) {
                 LOGGER.warn("not in main component, skipping Load: {}", l.getId());
                 continue;
             }
@@ -472,7 +468,7 @@ public class EurostagEchExport {
         }
         for (DanglingLine dl : Identifiables.sort(network.getDanglingLines())) {
             // skip dls not in the main connected component
-            if (config.isExportMainCCOnly() && (ConnectedComponents.getCcNum(EchUtil.getBus(dl.getTerminal(), config)) != Component.MAIN_NUM)) {
+            if (config.isExportMainCCOnly() && !EchUtil.isInMainCc(dl, config.isNoSwitch())) {
                 LOGGER.warn("not in main component, skipping DanglingLine: {}", dl.getId());
                 continue;
             }
@@ -484,7 +480,7 @@ public class EurostagEchExport {
     private void createGenerators(EsgNetwork esgNetwork) {
         for (Generator g : Identifiables.sort(network.getGenerators())) {
             // skip generators not in the main connected component
-            if (config.isExportMainCCOnly() && (ConnectedComponents.getCcNum(EchUtil.getBus(g.getTerminal(), config)) != Component.MAIN_NUM)) {
+            if (config.isExportMainCCOnly() && !EchUtil.isInMainCc(g, config.isNoSwitch())) {
                 LOGGER.warn("not in main component, skipping Generator: {}", g.getId());
                 continue;
             }
@@ -528,7 +524,7 @@ public class EurostagEchExport {
     private void createBanks(EsgNetwork esgNetwork) {
         for (ShuntCompensator sc : Identifiables.sort(network.getShunts())) {
             // skip shunts not in the main connected component
-            if (config.isExportMainCCOnly() && (ConnectedComponents.getCcNum(EchUtil.getBus(sc.getTerminal(), config)) != Component.MAIN_NUM)) {
+            if (config.isExportMainCCOnly() && !EchUtil.isInMainCc(sc, config.isNoSwitch())) {
                 LOGGER.warn("not in main component, skipping ShuntCompensator: {}", sc.getId());
                 continue;
             }
@@ -550,7 +546,7 @@ public class EurostagEchExport {
     private void createStaticVarCompensators(EsgNetwork esgNetwork) {
         for (StaticVarCompensator svc : Identifiables.sort(network.getStaticVarCompensators())) {
             // skip SVCs not in the main connected component
-            if (config.isExportMainCCOnly() && (ConnectedComponents.getCcNum(EchUtil.getBus(svc.getTerminal(), config)) != Component.MAIN_NUM)) {
+            if (config.isExportMainCCOnly() && !EchUtil.isInMainCc(svc, config.isNoSwitch())) {
                 LOGGER.warn("not in main component, skipping StaticVarCompensator: {}", svc.getId());
                 continue;
             }

--- a/eurostag-ech-export/src/main/java/eu/itesla_project/iidm/eurostag/export/EurostagEchExportConfig.java
+++ b/eurostag-ech-export/src/main/java/eu/itesla_project/iidm/eurostag/export/EurostagEchExportConfig.java
@@ -29,6 +29,7 @@ public class EurostagEchExportConfig {
     private static final boolean DEFAULT_NOSWITCH = false;
     private static final boolean DEFAULT_SVC_AS_FIXED_INJECTION_IN_LF = false;
     private static final boolean DEFAULT_SPECIFIC_COMPATIBILITY = false;
+    private static final boolean DEFAULT_EXPORT_MAIN_CC_ONLY = false;
 
     private boolean noGeneratorMinMaxQ;
 
@@ -42,20 +43,22 @@ public class EurostagEchExportConfig {
 
     private final Character forbiddenCharactersReplacement;
 
+    private boolean exportMainCCOnly;
+
     public EurostagEchExportConfig() {
-        this(false, false, DEFAULT_FORBIDDEN_CHARACTERS, DEFAULT_FORBIDDEN_CHARACTERS_REPLACEMENT, DEFAULT_SVC_AS_FIXED_INJECTION_IN_LF, DEFAULT_SPECIFIC_COMPATIBILITY);
+        this(false, false, DEFAULT_FORBIDDEN_CHARACTERS, DEFAULT_FORBIDDEN_CHARACTERS_REPLACEMENT, DEFAULT_SVC_AS_FIXED_INJECTION_IN_LF, DEFAULT_SPECIFIC_COMPATIBILITY, DEFAULT_EXPORT_MAIN_CC_ONLY);
     }
 
     public EurostagEchExportConfig(boolean noGeneratorMinMaxQ) {
-        this(noGeneratorMinMaxQ, false, DEFAULT_FORBIDDEN_CHARACTERS, DEFAULT_FORBIDDEN_CHARACTERS_REPLACEMENT, DEFAULT_SVC_AS_FIXED_INJECTION_IN_LF, DEFAULT_SPECIFIC_COMPATIBILITY);
+        this(noGeneratorMinMaxQ, false, DEFAULT_FORBIDDEN_CHARACTERS, DEFAULT_FORBIDDEN_CHARACTERS_REPLACEMENT, DEFAULT_SVC_AS_FIXED_INJECTION_IN_LF, DEFAULT_SPECIFIC_COMPATIBILITY, DEFAULT_EXPORT_MAIN_CC_ONLY);
     }
 
     public EurostagEchExportConfig(boolean noGeneratorMinMaxQ, boolean noSwitch) {
-        this(noGeneratorMinMaxQ, noSwitch, DEFAULT_FORBIDDEN_CHARACTERS, DEFAULT_FORBIDDEN_CHARACTERS_REPLACEMENT, DEFAULT_SVC_AS_FIXED_INJECTION_IN_LF, DEFAULT_SPECIFIC_COMPATIBILITY);
+        this(noGeneratorMinMaxQ, noSwitch, DEFAULT_FORBIDDEN_CHARACTERS, DEFAULT_FORBIDDEN_CHARACTERS_REPLACEMENT, DEFAULT_SVC_AS_FIXED_INJECTION_IN_LF, DEFAULT_SPECIFIC_COMPATIBILITY, DEFAULT_EXPORT_MAIN_CC_ONLY);
     }
 
 
-    public EurostagEchExportConfig(boolean noGeneratorMinMaxQ, boolean noSwitch, String forbiddenCharacters, Character forbiddenCharactersReplacement, boolean svcAsFixedInjectionInLF, boolean specificCompatibility) {
+    public EurostagEchExportConfig(boolean noGeneratorMinMaxQ, boolean noSwitch, String forbiddenCharacters, Character forbiddenCharactersReplacement, boolean svcAsFixedInjectionInLF, boolean specificCompatibility, boolean exportMainCCOnly) {
         this.forbiddenCharacters = Objects.requireNonNull(forbiddenCharacters, "forbiddenCharacters string must be not null");
         this.forbiddenCharactersReplacement = Objects.requireNonNull(forbiddenCharactersReplacement, "forbiddenCharactersReplacement (single char) string must not be null");
         this.noGeneratorMinMaxQ = noGeneratorMinMaxQ;
@@ -70,6 +73,7 @@ public class EurostagEchExportConfig {
         if (forbiddenCharacters.contains(forbiddenCharactersReplacement.toString())) {
             throw new IllegalArgumentException("forbiddenCharactersReplacement " + forbiddenCharactersReplacement + " must not appear also in the forbiddenCharacters string: " + forbiddenCharacters);
         }
+        this.exportMainCCOnly = exportMainCCOnly;
     }
 
     public boolean isNoGeneratorMinMaxQ() {
@@ -96,6 +100,10 @@ public class EurostagEchExportConfig {
         return forbiddenCharactersReplacement;
     }
 
+    public boolean isExportMainCCOnly() {
+        return exportMainCCOnly;
+    }
+
     public static EurostagEchExportConfig load() {
         return load(PlatformConfig.defaultConfig());
     }
@@ -117,10 +125,11 @@ public class EurostagEchExportConfig {
                 throw new IllegalArgumentException("forbiddenCharactersReplacement must be a single character: " + replacementCharString);
             }
             Character forbiddenCharactersReplacement = replacementCharString.charAt(0);
-            return new EurostagEchExportConfig(noGeneratorMinMaxQ, noSwitch, forbiddenCharacters, forbiddenCharactersReplacement, svcAsFixedInjectionInLF, specificCompatibility);
+            boolean exportMainCCOnly = config.getBooleanProperty("exportMainCCOnly", DEFAULT_EXPORT_MAIN_CC_ONLY);
+            return new EurostagEchExportConfig(noGeneratorMinMaxQ, noSwitch, forbiddenCharacters, forbiddenCharactersReplacement, svcAsFixedInjectionInLF, specificCompatibility, exportMainCCOnly);
         } else {
             LOGGER.warn("no eurostag-ech-export config found: Using defaults.");
-            return new EurostagEchExportConfig(DEFAULT_NOGENERATORMINMAXQ, DEFAULT_NOSWITCH, DEFAULT_FORBIDDEN_CHARACTERS, DEFAULT_FORBIDDEN_CHARACTERS_REPLACEMENT, DEFAULT_SVC_AS_FIXED_INJECTION_IN_LF, specificCompatibility);
+            return new EurostagEchExportConfig(DEFAULT_NOGENERATORMINMAXQ, DEFAULT_NOSWITCH, DEFAULT_FORBIDDEN_CHARACTERS, DEFAULT_FORBIDDEN_CHARACTERS_REPLACEMENT, DEFAULT_SVC_AS_FIXED_INJECTION_IN_LF, specificCompatibility, DEFAULT_EXPORT_MAIN_CC_ONLY);
         }
     }
 
@@ -132,6 +141,7 @@ public class EurostagEchExportConfig {
                 ", forbiddenCharactersReplacement=" + forbiddenCharactersReplacement +
                 ", svcAsFixedInjectionInLF=" + svcAsFixedInjectionInLF +
                 ", specificCompatibility=" + specificCompatibility +
+                ", exportMainCCOnly=" + exportMainCCOnly +
                 "]";
     }
 

--- a/eurostag-ech-export/src/main/java/eu/itesla_project/iidm/eurostag/export/EurostagFakeNodes.java
+++ b/eurostag-ech-export/src/main/java/eu/itesla_project/iidm/eurostag/export/EurostagFakeNodes.java
@@ -63,6 +63,8 @@ public final class EurostagFakeNodes {
         countUsesMap.getAndIncrement(EchUtil.FAKE_NODE_NAME1);
         fakeNodesMap.put(EchUtil.FAKE_NODE_NAME2, EchUtil.FAKE_NODE_NAME2);
         countUsesMap.getAndIncrement(EchUtil.FAKE_NODE_NAME2);
+        Identifiables.sort(network.getVoltageLevels()).stream().forEach(vl -> {
+        });
 
         Identifiables.sort(network.getVoltageLevels()).stream().map(VoltageLevel::getId).forEach(vlId ->
                 fakeNodesMap.put(vlId, newEsgId(fakeNodesMap, vlId)));

--- a/eurostag-ech-export/src/main/java/eu/itesla_project/iidm/eurostag/export/EurostagFakeNodes.java
+++ b/eurostag-ech-export/src/main/java/eu/itesla_project/iidm/eurostag/export/EurostagFakeNodes.java
@@ -63,8 +63,6 @@ public final class EurostagFakeNodes {
         countUsesMap.getAndIncrement(EchUtil.FAKE_NODE_NAME1);
         fakeNodesMap.put(EchUtil.FAKE_NODE_NAME2, EchUtil.FAKE_NODE_NAME2);
         countUsesMap.getAndIncrement(EchUtil.FAKE_NODE_NAME2);
-        Identifiables.sort(network.getVoltageLevels()).stream().forEach(vl -> {
-        });
 
         Identifiables.sort(network.getVoltageLevels()).stream().map(VoltageLevel::getId).forEach(vlId ->
                 fakeNodesMap.put(vlId, newEsgId(fakeNodesMap, vlId)));

--- a/iidm-ddb/iidm-ddb-eurostag-import-export/src/main/java/eu/itesla_project/iidm/ddb/eurostag_imp_exp/DdExportConfig.java
+++ b/iidm-ddb/iidm-ddb-eurostag-import-export/src/main/java/eu/itesla_project/iidm/ddb/eurostag_imp_exp/DdExportConfig.java
@@ -31,6 +31,8 @@ public class DdExportConfig {
     private static final float DEFAULT_LOAD_PATTERN_ALPHA = 1;
     private static final float DEFAULT_LOAD_PATTERN_BETA = 2;
     private static final boolean DEFAULT_GENPQFILTER = false;
+    private static final boolean DEFAULT_EXPORT_MAIN_CC_ONLY = false;
+    private static final boolean DEFAULT_NOSWITCH = false;
 
     private boolean automatonA11;
     private boolean automatonA12;
@@ -46,6 +48,8 @@ public class DdExportConfig {
     private float loadPatternAlpha;
     private float loadPatternBeta;
     private boolean gensPQfilter;
+    private boolean exportMainCCOnly;
+    private boolean noSwitch;
 
     public static DdExportConfig load() {
         boolean automatonA11 = DEFAULT_AUTOMATON_A11;
@@ -62,7 +66,8 @@ public class DdExportConfig {
         float loadPatternAlpha = DEFAULT_LOAD_PATTERN_ALPHA;
         float loadPatternBeta = DEFAULT_LOAD_PATTERN_BETA;
         boolean gensPQfilter = DEFAULT_GENPQFILTER;
-
+        boolean exportMainCCOnly = DEFAULT_EXPORT_MAIN_CC_ONLY;
+        boolean noSwitch = DEFAULT_NOSWITCH;
 
         if (PlatformConfig.defaultConfig().moduleExists(MODULE_NAME)) {
             ModuleConfig config = PlatformConfig.defaultConfig().getModuleConfig(MODULE_NAME);
@@ -81,21 +86,28 @@ public class DdExportConfig {
             loadPatternBeta = config.getFloatProperty("loadPatternBeta", DEFAULT_LOAD_PATTERN_BETA);
             gensPQfilter = config.getBooleanProperty("gensPQfilter", DEFAULT_GENPQFILTER);
         }
+
+        if (PlatformConfig.defaultConfig().moduleExists("eurostag-ech-export")) {
+            ModuleConfig config = PlatformConfig.defaultConfig().getModuleConfig("eurostag-ech-export");
+            exportMainCCOnly = config.getBooleanProperty("exportMainCCOnly", DEFAULT_EXPORT_MAIN_CC_ONLY);
+            noSwitch = config.getBooleanProperty("noSwitch", DEFAULT_NOSWITCH);
+        }
+
         return new DdExportConfig(automatonA11, automatonA12, automatonA14, importExportRST, importExportACMC,
                                   lvLoadModeling, rstRegulInjector, rstRegulGenerator, rstRegulGeneratorDelete,
-                                  acmcRegul, rstPilotGenerators, loadPatternAlpha, loadPatternBeta, gensPQfilter);
+                                  acmcRegul, rstPilotGenerators, loadPatternAlpha, loadPatternBeta, gensPQfilter, exportMainCCOnly, noSwitch);
     }
 
     public DdExportConfig() {
         this(DEFAULT_AUTOMATON_A11, DEFAULT_AUTOMATON_A12, DEFAULT_AUTOMATON_A14, DEFAULT_RST, DEFAULT_ACMC,
                 DEFAULT_LV_LOAD_MODELING, DEFAULT_RST_REGUL_INJECTOR, DEFAULT_RST_REGUL_GENERATOR, DEFAULT_RST_REGUL_GENERATOR_DELETE,
-                DEFAULT_ACMC_REGUL, DEFAULT_RST_PILOT_GENERATORS, DEFAULT_LOAD_PATTERN_ALPHA, DEFAULT_LOAD_PATTERN_BETA, DEFAULT_GENPQFILTER);
+                DEFAULT_ACMC_REGUL, DEFAULT_RST_PILOT_GENERATORS, DEFAULT_LOAD_PATTERN_ALPHA, DEFAULT_LOAD_PATTERN_BETA, DEFAULT_GENPQFILTER, DEFAULT_EXPORT_MAIN_CC_ONLY, DEFAULT_NOSWITCH);
     }
 
     public DdExportConfig(boolean automatonA11, boolean automatonA12, boolean automatonA14, boolean importExportRST,
                           boolean importExportACMC, boolean lvLoadModeling, String rstRegulInjector,
                           String rstRegulGenerator, String rstRegulGeneratorDelete, String acmcRegul,
-                          String rstPilotGenerators, float loadPatternAlpha, float loadPatternBeta, boolean gensPQfilter) {
+                          String rstPilotGenerators, float loadPatternAlpha, float loadPatternBeta, boolean gensPQfilter, boolean exportMainCCOnly, boolean noSwitch) {
         this.automatonA11 = automatonA11;
         this.automatonA12 = automatonA12;
         this.automatonA14 = automatonA14;
@@ -110,6 +122,8 @@ public class DdExportConfig {
         this.loadPatternAlpha = loadPatternAlpha;
         this.loadPatternBeta = loadPatternBeta;
         this.gensPQfilter = gensPQfilter;
+        this.exportMainCCOnly = exportMainCCOnly;
+        this.noSwitch = noSwitch;
     }
 
     public boolean getAutomatonA11() {
@@ -230,5 +244,13 @@ public class DdExportConfig {
 
     public void setGensPQfilter(boolean gensPQfilter) {
         this.gensPQfilter = gensPQfilter;
+    }
+
+    public boolean isExportMainCCOnly() {
+        return exportMainCCOnly;
+    }
+
+    public boolean isNoSwitch() {
+        return noSwitch;
     }
 }

--- a/iidm-ddb/iidm-ddb-eurostag-import-export/src/main/java/eu/itesla_project/iidm/ddb/eurostag_imp_exp/DdbDtaImpExp.java
+++ b/iidm-ddb/iidm-ddb-eurostag-import-export/src/main/java/eu/itesla_project/iidm/ddb/eurostag_imp_exp/DdbDtaImpExp.java
@@ -845,13 +845,18 @@ public class DdbDtaImpExp implements DynamicDatabaseClient {
         return false;
     }
 
-    public static Bus getBus(Terminal t, DdExportConfig config) {
-        if (config.isNoSwitch()) {
+    public Bus getBus(Terminal t, boolean noswitch) {
+        if (noswitch) {
             return t.getBusView().getBus();
         } else {
             return t.getBusBreakerView().getBus();
         }
     }
+
+    public boolean isInMainCc(Injection injection, boolean noswitch) {
+        return ConnectedComponents.getCcNum(getBus(injection.getTerminal(), noswitch)) == Component.MAIN_NUM;
+    }
+
 
 
     /**
@@ -906,7 +911,7 @@ public class DdbDtaImpExp implements DynamicDatabaseClient {
             log.warn("Skipped generators: network, generator Id, min P, P, max P");
             for (Generator g : Identifiables.sort(network.getGenerators())) {
                 // skip generators not in the main connected component
-                if (configExport.isExportMainCCOnly() && (ConnectedComponents.getCcNum(getBus(g.getTerminal(), configExport)) != Component.MAIN_NUM)) {
+                if (configExport.isExportMainCCOnly() && !isInMainCc(g, configExport.isNoSwitch())) {
                     log.warn("not in main component, skipping Generator: {}", g.getId());
                     continue;
                 }
@@ -921,7 +926,7 @@ public class DdbDtaImpExp implements DynamicDatabaseClient {
             //collects SVCs ids, filtering out the regulationMode OFF cases
             for (StaticVarCompensator svc : Identifiables.sort(network.getStaticVarCompensators())) {
                 // skip SVCs not in the main connected component
-                if (configExport.isExportMainCCOnly() && (ConnectedComponents.getCcNum(getBus(svc.getTerminal(), configExport)) != Component.MAIN_NUM)) {
+                if (configExport.isExportMainCCOnly() && !isInMainCc(svc, configExport.isNoSwitch())) {
                     log.warn("not in main component, skipping StaticVarCompensator: {}", svc.getId());
                     continue;
                 }

--- a/iidm-ddb/iidm-ddb-eurostag-import-export/src/main/java/eu/itesla_project/iidm/ddb/eurostag_imp_exp/DdbDtaImpExp.java
+++ b/iidm-ddb/iidm-ddb-eurostag-import-export/src/main/java/eu/itesla_project/iidm/ddb/eurostag_imp_exp/DdbDtaImpExp.java
@@ -7,6 +7,7 @@
 package eu.itesla_project.iidm.ddb.eurostag_imp_exp;
 
 import com.google.common.collect.Sets;
+import com.powsybl.iidm.network.util.ConnectedComponents;
 import eu.itesla_project.iidm.ddb.eurostag_imp_exp.utils.Utils;
 import eu.itesla_project.iidm.ddb.model.*;
 import eu.itesla_project.iidm.ddb.service.DDBManager;
@@ -844,6 +845,15 @@ public class DdbDtaImpExp implements DynamicDatabaseClient {
         return false;
     }
 
+    public static Bus getBus(Terminal t, DdExportConfig config) {
+        if (config.isNoSwitch()) {
+            return t.getBusView().getBus();
+        } else {
+            return t.getBusBreakerView().getBus();
+        }
+    }
+
+
     /**
      * in the workingDir, write eurostag dynamic data (fileName) for a given list of cimIDs, and regulator files (.fri, .frm, .par, .pcp, rcp)
      *      *
@@ -893,8 +903,13 @@ public class DdbDtaImpExp implements DynamicDatabaseClient {
 
             List<String> cimIds = new ArrayList<>(network.getGeneratorCount());
             // collect generators cim ids for the DTA exporter
-            log.warn("Skipping generators: network, generator Id, min P, P, max P");
+            log.warn("Skipped generators: network, generator Id, min P, P, max P");
             for (Generator g : Identifiables.sort(network.getGenerators())) {
+                // skip generators not in the main connected component
+                if (configExport.isExportMainCCOnly() && (ConnectedComponents.getCcNum(getBus(g.getTerminal(), configExport)) != Component.MAIN_NUM)) {
+                    log.warn("not in main component, skipping Generator: {}", g.getId());
+                    continue;
+                }
                 if (!filteredGenerator(g)) {
                     cimIds.add(g.getId());
                 } else {
@@ -905,6 +920,11 @@ public class DdbDtaImpExp implements DynamicDatabaseClient {
 
             //collects SVCs ids, filtering out the regulationMode OFF cases
             for (StaticVarCompensator svc : Identifiables.sort(network.getStaticVarCompensators())) {
+                // skip SVCs not in the main connected component
+                if (configExport.isExportMainCCOnly() && (ConnectedComponents.getCcNum(getBus(svc.getTerminal(), configExport)) != Component.MAIN_NUM)) {
+                    log.warn("not in main component, skipping StaticVarCompensator: {}", svc.getId());
+                    continue;
+                }
                 if (svc.getRegulationMode() != StaticVarCompensator.RegulationMode.OFF) {
                     cimIds.add(svc.getId());
                 } else {


### PR DESCRIPTION
New option: export only the main network component for the simulation.
It can avoid to have useless component parts during the simulation.