### PR TITLE
Update continuous integration build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,7 @@ before_install:
 - chmod 600 /tmp/id_rsa_gandi
 - ssh-add /tmp/id_rsa_gandi
 
-install:
-# Build iPST core
-- git clone https://github.com/powsybl/powsybl-core powsybl/powsybl-core
-- pushd powsybl/powsybl-core && mvn install && popd
-
 script:
-- cd ${TRAVIS_BUILD_DIR}
 - mvn clean install jacoco:report coveralls:report
 
 addons:
@@ -25,5 +19,3 @@ addons:
       - graphviz
 after_success:
 - test $TRAVIS_BRANCH = "master" && test $TRAVIS_PULL_REQUEST = "false" && mvn javadoc:javadoc && pushd $TRAVIS_BUILD_DIR/target/site/apidocs && zip -r /tmp/ipst-javadoc.zip . && sftp $JAVADOC_USER@sftp.dc0.gpaas.net:vhosts/www.itesla-pst.org/htdocs/javadoc <<< $'put /tmp/ipst-javadoc.zip' && popd
-- test $TRAVIS_BRANCH = "master" && test $TRAVIS_PULL_REQUEST = "false" && cd $TRAVIS_BUILD_DIR/powsybl/powsybl-core && mvn javadoc:javadoc && cd target/site/apidocs && zip -r /tmp/powsybl-core-javadoc.zip . && sftp $JAVADOC_USER@sftp.dc0.gpaas.net:vhosts/www.itesla-pst.org/htdocs/javadoc <<< $'put /tmp/powsybl-core-javadoc.zip'
-


### PR DESCRIPTION
powsybl jars are now taken from maven central,
we don't need to build them anymore.